### PR TITLE
Link to test reports will always go to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ An example of [user journey testing](https://martinfowler.com/bliki/UserJourneyT
 
 The build runs on [CircleCI](https://circleci.com/gh/johnboyes/gauge-taiko-journey-test-example)
 
-[Test reports for the latest build on master](https://circleci.com/api/v1.1/project/github/johnboyes/gauge-taiko-journey-test-example/latest/artifacts/0/home/circleci/gauge-taiko-journey-test-example/reports/html-report/index.html?branch=master&filter=successful)
+[Test reports for the latest build on master](https://circleci.com/api/v1.1/project/github/johnboyes/gauge-taiko-journey-test-example/latest/artifacts/0/home/circleci/gauge-taiko-journey-test-example/reports/html-report/index.html?branch=master)


### PR DESCRIPTION
Prior to this commit the link to the test reports in the README was
always going to the latest successful build.  This behaviour was
incorrect, as we always want to link to the latest build's test reports,
regardless of whether that build succeeded or failed.