### PR TITLE
Remove the Taiko installation in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ jobs:
       - run: npm set prefix=/home/circleci/npm && echo 'export PATH=/home/circleci/npm/bin:$PATH' >> $BASH_ENV
       - run: npm install -g npm@latest
       - run: npm install
-      - run: npm install -g taiko
       - run: npm install -g @getgauge/cli --unsafe-perm
       - run: gauge install
       - run: gauge telemetry off


### PR DESCRIPTION
https://gauge.org/2018/10/23/taiko-beta-reliable-browser-automation/
indicates that there is no need to install Taiko independently unless
you want to run Taiko standalone