### PR TITLE
Fix build failing due to old Node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   circleci-gauge-executor:
     docker:
-      - image: circleci/node:11.9.0-browsers
+      - image: circleci/node:16.13.0-browsers
 
 jobs:
   build:


### PR DESCRIPTION
The build was failing because NPM was not compatible with the version of
Node.